### PR TITLE
Purge warnings

### DIFF
--- a/physics/blended.hpp
+++ b/physics/blended.hpp
@@ -26,7 +26,7 @@ namespace jpacPhoto
         {
             initialize(0);
             if (bounds[0] > bounds[1]) warning("jpacPhoto::blended", "Lower limit bigger than upper limit!");
-            if ((amps[0]->_kinematics != amps[1]->_kinematics) || (xkinem != amps[0]->_kinematics))
+            if ((amps[0]->get_kinematics() != amps[1]->get_kinematics()) || (xkinem != amps[0]->get_kinematics()))
             {
                 warning("jpacPhoto::blended", "Kinematics instances not compatible with each other!");
             };
@@ -35,7 +35,7 @@ namespace jpacPhoto
         // Calculate each helicity amplitude 
         inline complex helicity_amplitude(std::array<int,4> helicities, double s, double t)
         {
-            int index = find_helicity(helicities, _kinematics->get_meson_JP()[0], _kinematics->get_baryon_JP()[0], _kinematics->is_photon());
+            int index = find_helicity(helicities, get_kinematics()->get_meson_JP()[0], get_kinematics()->get_baryon_JP()[0], get_kinematics()->is_photon());
             if (s < _bounds[0]) return _low->helicity_amplitude(helicities, s, t);
             if (s > _bounds[1]) return _high->helicity_amplitude(helicities, s, t);
 

--- a/src/bilinear.hpp
+++ b/src/bilinear.hpp
@@ -82,7 +82,7 @@ namespace jpacPhoto
         };
 
         // Get the rank of the tensor (number of open indicies)
-        const inline int rank(){ return Rank; };
+        inline int rank() const{ return Rank; };
 
         protected:
 

--- a/src/bilinear.hpp
+++ b/src/bilinear.hpp
@@ -82,7 +82,7 @@ namespace jpacPhoto
         };
 
         // Get the rank of the tensor (number of open indicies)
-        inline int rank() const{ return Rank; };
+        inline unsigned int rank() const{ return Rank; };
 
         protected:
 

--- a/src/lorentz_tensor.hpp
+++ b/src/lorentz_tensor.hpp
@@ -87,7 +87,7 @@ namespace jpacPhoto
             Type prod = _subtensors[0]->operator()(ind0);
             running_index += subrank0;
 
-            for (int i = 1; i < _subtensors.size(); i++)
+            for (uint i = 1; i < _subtensors.size(); i++)
             {
                 int subrank = _subtensors[i]->rank();
                 prod *= _subtensors[i]->operator()( std::vector<lorentz_index>(running_index, running_index + subrank));

--- a/src/lorentz_tensor.hpp
+++ b/src/lorentz_tensor.hpp
@@ -49,7 +49,7 @@ namespace jpacPhoto
         {};
 
         // Get the rank of the tensor (number of open indicies)
-        const inline int rank(){ return Rank; };
+        inline int rank() const{ return Rank; };
 
         // Re-assignment, just makes a copy basically
         inline lorentz_tensor<Type,Rank> & operator=(lorentz_tensor<Type,Rank> const & T)

--- a/src/lorentz_tensor.hpp
+++ b/src/lorentz_tensor.hpp
@@ -49,7 +49,7 @@ namespace jpacPhoto
         {};
 
         // Get the rank of the tensor (number of open indicies)
-        inline int rank() const{ return Rank; };
+        inline unsigned int rank() const{ return Rank; };
 
         // Re-assignment, just makes a copy basically
         inline lorentz_tensor<Type,Rank> & operator=(lorentz_tensor<Type,Rank> const & T)

--- a/src/tensor_object.hpp
+++ b/src/tensor_object.hpp
@@ -94,7 +94,7 @@ namespace jpacPhoto
 
         inline Type operator()(std::vector<lorentz_index> indices)
         {
-            if (indices.size() != rank()) return error("lorentz_tensor", "Incorrect number of indices passed!", NaN<Type>());
+	  if (indices.size() != static_cast<uint>(rank())) return error("lorentz_tensor", "Incorrect number of indices passed!", NaN<Type>());
             int mu = +indices[0];
             return _entries[mu];
         };
@@ -138,7 +138,7 @@ namespace jpacPhoto
 
         inline Type operator()(std::vector<lorentz_index> indices)
         {
-            if (indices.size() != rank()) return error("lorentz_tensor", "Incorrect number of indices passed!", NaN<Type>());
+	  if (indices.size() != static_cast<uint>(rank())) return error("lorentz_tensor", "Incorrect number of indices passed!", NaN<Type>());
             int mu = +indices[0], nu = +indices[1];
             return (mu == nu) ? complex((mu == 0) - (mu != 0)) * id : z;
         };

--- a/src/tensor_object.hpp
+++ b/src/tensor_object.hpp
@@ -70,7 +70,7 @@ namespace jpacPhoto
     class tensor_object 
     {
         public: 
-        virtual int rank() const = 0;
+        virtual unsigned int rank() const = 0;
         virtual Type operator()(std::vector<lorentz_index> indices) = 0;
 
         virtual std::shared_ptr<tensor_object<dirac_matrix>> matrixify(){ return nullptr; };
@@ -90,11 +90,11 @@ namespace jpacPhoto
         {};
 
         // Always a rank 1 tensor
-        inline int rank() const{ return 1; };
+        inline unsigned int rank() const{ return 1; };
 
         inline Type operator()(std::vector<lorentz_index> indices)
         {
-	  if (indices.size() != static_cast<uint>(rank())) return error("lorentz_tensor", "Incorrect number of indices passed!", NaN<Type>());
+	  if (indices.size() != rank()) return error("lorentz_tensor", "Incorrect number of indices passed!", NaN<Type>());
             int mu = +indices[0];
             return _entries[mu];
         };
@@ -134,11 +134,11 @@ namespace jpacPhoto
         raw_metric_tensor(){};
 
         // Always a rank 2 tensor
-        inline int rank() const{ return 2; };
+        inline unsigned int rank() const{ return 2; };
 
         inline Type operator()(std::vector<lorentz_index> indices)
         {
-	  if (indices.size() != static_cast<uint>(rank())) return error("lorentz_tensor", "Incorrect number of indices passed!", NaN<Type>());
+	  if (indices.size() != rank()) return error("lorentz_tensor", "Incorrect number of indices passed!", NaN<Type>());
             int mu = +indices[0], nu = +indices[1];
             return (mu == nu) ? complex((mu == 0) - (mu != 0)) * id : z;
         };
@@ -168,7 +168,7 @@ namespace jpacPhoto
         raw_levicivita_tensor(){};
 
         // Always a rank 2 tensor
-        inline int rank() const{ return 4; };
+        inline unsigned int rank() const{ return 4; };
 
         inline Type operator()(std::vector<lorentz_index> indices)
         {

--- a/src/tensor_object.hpp
+++ b/src/tensor_object.hpp
@@ -70,7 +70,7 @@ namespace jpacPhoto
     class tensor_object 
     {
         public: 
-        virtual const int rank() = 0;
+        virtual int rank() const = 0;
         virtual Type operator()(std::vector<lorentz_index> indices) = 0;
 
         virtual std::shared_ptr<tensor_object<dirac_matrix>> matrixify(){ return nullptr; };
@@ -90,7 +90,7 @@ namespace jpacPhoto
         {};
 
         // Always a rank 1 tensor
-        inline const int rank(){ return 1; };
+        inline int rank() const{ return 1; };
 
         inline Type operator()(std::vector<lorentz_index> indices)
         {
@@ -134,7 +134,7 @@ namespace jpacPhoto
         raw_metric_tensor(){};
 
         // Always a rank 2 tensor
-        inline const int rank(){ return 2; };
+        inline int rank() const{ return 2; };
 
         inline Type operator()(std::vector<lorentz_index> indices)
         {
@@ -168,7 +168,7 @@ namespace jpacPhoto
         raw_levicivita_tensor(){};
 
         // Always a rank 2 tensor
-        inline const int rank(){ return 4; };
+        inline int rank() const{ return 4; };
 
         inline Type operator()(std::vector<lorentz_index> indices)
         {


### PR DESCRIPTION
Use get_kinematics in blended
Purge compiler warnings related to 
inline int rank(){ return Rank; };

Note I cast to static_int in if condition, however a better option might be to just return a uint rather than an int if it is >=0 always.
Also I changed the function to const rather than the return, perhaps there was a reason for the return being const ? Anyway, my compiler did not like it...